### PR TITLE
Non-English

### DIFF
--- a/src/extractors/ResultsPageExtractor.ts
+++ b/src/extractors/ResultsPageExtractor.ts
@@ -65,18 +65,24 @@ export class ResultsPageExtractor {
       .filter((p) => Number(p.runs) === 0)
       .map(() => "Unknown");
 
-    
     this.newestParkrunners = this.finishers
       .filter((p) => Number(p.runs) === 1)
       .map((p) => p.name);
 
     this.firstTimers = Array.from(rowElements)
-      ?.filter((tr) => tr.querySelector("td.Results-table-td--ft") && Number(tr.dataset.runs) > 1)
-      ?.map((tr) => tr.dataset.name as string);
+      .filter(
+        (tr) =>
+          tr.querySelector("td.Results-table-td--ft") &&
+          Number(tr.dataset.runs) > 1
+      )
+      .map((tr) => tr.dataset.name as string);
 
-    this.finishersWithNewPBs = this.finishers
-      .filter((p) => p.achievement === "New PB!")
-      .map((p) => `${p.name} (${p.time})`);
+    this.finishersWithNewPBs = Array.from(rowElements)
+      .filter((tr) => tr.querySelector("td.Results-table-td--pb"))
+      .map(
+        (tr) =>
+          `${tr.dataset.name} (${tr.querySelector(".Results-table-td--time .compact")?.textContent})`
+      );
 
     this.runningWalkingGroups = Array.from(
       new Set(this.finishers.map((p) => p?.club || "").filter((c) => c !== ""))

--- a/src/extractors/ResultsPageExtractor.ts
+++ b/src/extractors/ResultsPageExtractor.ts
@@ -88,36 +88,22 @@ export class ResultsPageExtractor {
       new Set(this.finishers.map((p) => p?.club || "").filter((c) => c !== ""))
     );
 
-    const statElements: NodeListOf<HTMLDivElement> =
-      document.querySelectorAll(".aStat");
+    const [
+      _events,
+      finishers,
+      finishes,
+      volunteers,
+      pbs,
+      _averageFinishTime,
+      _groups,
+    ] = Array.from(document.querySelectorAll(".aStat")).map((s) =>
+      s?.textContent?.replace(/^[^:]*:/, "").trim()
+    );
 
-    statElements?.forEach((e) => {
-      const key = e.firstChild?.textContent
-        ?.trim()
-        ?.toLocaleLowerCase()
-        ?.replace(":", "");
-      if (
-        key !== undefined &&
-        e.firstElementChild !== null &&
-        Object.hasOwn(this.facts, key)
-      ) {
-        const value = Number(e.firstElementChild.textContent);
-        switch (key) {
-          case "finishers":
-            this.facts.finishers = value;
-            break;
-          case "finishes":
-            this.facts.finishes = value;
-            break;
-          case "pbs":
-            this.facts.pbs = value;
-            break;
-          case "volunteers":
-            this.facts.volunteers = value;
-            break;
-        }
-      }
-    });
+    this.facts.finishers = finishers ? Number(finishers) : 0;
+    this.facts.finishes = finishes ? Number(finishes) : 0;
+    this.facts.pbs = pbs ? Number(pbs) : 0;
+    this.facts.volunteers = volunteers ? Number(volunteers) : 0;
   }
 
   private volunteerElements(): NodeListOf<HTMLAnchorElement> | [] {

--- a/src/extractors/ResultsPageExtractor.ts
+++ b/src/extractors/ResultsPageExtractor.ts
@@ -65,13 +65,14 @@ export class ResultsPageExtractor {
       .filter((p) => Number(p.runs) === 0)
       .map(() => "Unknown");
 
+    
     this.newestParkrunners = this.finishers
       .filter((p) => Number(p.runs) === 1)
       .map((p) => p.name);
 
-    this.firstTimers = this.finishers
-      .filter((p) => p.achievement === "First Timer!" && Number(p.runs) > 1)
-      .map((p) => p.name);
+    this.firstTimers = Array.from(rowElements)
+      ?.filter((tr) => tr.querySelector("td.Results-table-td--ft") && Number(tr.dataset.runs) > 1)
+      ?.map((tr) => tr.dataset.name as string);
 
     this.finishersWithNewPBs = this.finishers
       .filter((p) => p.achievement === "New PB!")


### PR DESCRIPTION
#### Context

It bugged me that a couple of the stats were based on strings being found in the results table, which doesn't work for results displayed in languages other than English.
 
#### Change

See individual commits for finer details.

#### Confirmation

Checked on German and Latvian sites.

![image](https://github.com/user-attachments/assets/e880dc1c-a943-46bd-bccb-4a339ed24a07)

Satisfying

#### Considerations

The stats are pretty brittle. Maybe I'll get rid of them.