### PR TITLE
fix(firefox): android take two

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,10 +8,11 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "eventuate.addon@johnsy.com",
-      "strict_min_version": "58.0",
-      "android": {
-        "id": "eventuate.addon@johnsy.com"
-      }
+      "strict_min_version": "58.0"
+    },
+    "gecko_android": {
+      "id": "eventuate.addon@johnsy.com",
+      "strict_min_version": "68.0"
     }
   },
   "icons": {


### PR DESCRIPTION
#### Context

1.4.0 isn't compatible with Android.

#### Change

See individual commits for finer details.

