### PR TITLE
fix(userscript): compatibility with github.com/quoid/userscripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ pnpm webpack --config webpack.bookmarklet.config.js
 ```
 
 The userscript can be installed in browsers that support userscript managers
-like Tampermonkey or Greasemonkey. The bookmarklet can be used in any browser,
+like [Tampermonkey][tampermonkey], [Userscripts][userscripts], or [Greasemonkey][greasemonkey]. The bookmarklet can be used in any browser,
 including Safari on iOS devices, by creating a bookmark with the generated
 JavaScript code.
 
@@ -216,6 +216,9 @@ The addon is available as open source under the terms of the [MIT License].
 [firefox]: https://mozilla.org/firefox
 [contributing]: docs/CONTRIBUTING.md
 [semantic-release]: https://github.com/semantic-release/semantic-release
+[tampermonkey]: https://www.tampermonkey.net/
+[userscripts]: https://github.com/quoid/userscripts
+[greasemonkey]: https://www.greasespot.net/
 
 <!-- Images -->
 

--- a/src/userscript.template.js
+++ b/src/userscript.template.js
@@ -4,6 +4,7 @@
 // @author       Pete Johns (@johnsyweb)
 // @downloadURL  https://johnsy.com/eventuate/eventuate.user.js
 // @grant        GM_addStyle
+// @grant        GM.addStyle
 // @homepage     https://johnsy.com/eventuate/
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=parkrun.com.au
 // @license      MIT
@@ -36,7 +37,24 @@
 // @version      ${version}
 // ==/UserScript==
 
-GM_addStyle(`
+// Polyfill for cross-compatibility between Userscripts and Tampermonkey
+const addStyle = (css) => {
+  if (typeof GM !== 'undefined' && GM.addStyle) {
+    // Userscripts
+    return GM.addStyle(css);
+  } else if (typeof GM_addStyle !== 'undefined') {
+    // Tampermonkey
+    return GM_addStyle(css);
+  } else {
+    // Fallback for environments without GM APIs
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.appendChild(style);
+    return style;
+  }
+};
+
+addStyle(`
 #eventuate::before {
   background-color: lightcoral;
   content: "\\26A0\\FE0F This information is drawn by Eventuate ${version} from the results table to facilitate writing a report. It is not a report in itself. \\26A0\\FE0F";


### PR DESCRIPTION
#### Context

Tampermonkey isn't working with Safari 26.0 (21622.1.16.11.2), so I installed Userscripts, which is nice. Unfortunately, it has a different API for using styles.

#### Change

See individual commits for finer details.

#### Confirmation

Tested locally with Safari and Firefox.

