### PR TITLE
ci: create aube update PRs with gh instead of peter-evans

### DIFF
--- a/.github/workflows/aube-update.yml
+++ b/.github/workflows/aube-update.yml
@@ -42,13 +42,23 @@ jobs:
         run: mise run test
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@271a8d4a0803a34955dd159102031f8e62f55259 # v7
-        with:
-          commit-message: 'chore(deps): update npm dependencies'
-          title: 'chore(deps): update npm dependencies'
-          body: |
-            Weekly automated dependency update via aube.
-
-            Requires manual review for allowBuilds changes and security advisories.
-          branch: chore/aube-deps-update
-          delete-branch: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B chore/aube-deps-update
+          git add aube-lock.yaml package.json aube-workspace.yaml
+          if git diff --staged --quiet; then
+            echo "No changes detected, skipping PR creation"
+            exit 0
+          fi
+          git commit -m 'chore(deps): update npm dependencies'
+          git push origin chore/aube-deps-update --force
+          body=$'Weekly automated dependency update via aube.\n\nRequires manual review for allowBuilds changes and security advisories.'
+          gh pr view chore/aube-deps-update >/dev/null 2>&1 || gh pr create \
+            --title 'chore(deps): update npm dependencies' \
+            --body "$body" \
+            --base main \
+            --head chore/aube-deps-update

--- a/.github/workflows/aube-update.yml
+++ b/.github/workflows/aube-update.yml
@@ -44,21 +44,4 @@ jobs:
       - name: Create pull request
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B chore/aube-deps-update
-          git add aube-lock.yaml package.json aube-workspace.yaml
-          if git diff --staged --quiet; then
-            echo "No changes detected, skipping PR creation"
-            exit 0
-          fi
-          git commit -m 'chore(deps): update npm dependencies'
-          git push origin chore/aube-deps-update --force
-          body=$'Weekly automated dependency update via aube.\n\nRequires manual review for allowBuilds changes and security advisories.'
-          gh pr view chore/aube-deps-update >/dev/null 2>&1 || gh pr create \
-            --title 'chore(deps): update npm dependencies' \
-            --body "$body" \
-            --base main \
-            --head chore/aube-deps-update
+        run: bash script/lib/create-aube-deps-pr

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -166,7 +166,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
-          path: |
+          path: &build-artefact-paths |
             dist/eventuate.js
             dist/eventuate.bookmarklet.js
             docs/eventuate.user.js
@@ -294,10 +294,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist-release
-          path: |
-            dist/eventuate.js
-            dist/eventuate.bookmarklet.js
-            docs/eventuate.user.js
+          path: *build-artefact-paths
           retention-days: 1
 
   # Deploy Pages after release (when we are releasing)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -167,9 +167,9 @@ jobs:
         with:
           name: dist
           path: |
-            eventuate.js
-            eventuate.bookmarklet.js
-            eventuate.user.js
+            dist/eventuate.js
+            dist/eventuate.bookmarklet.js
+            docs/eventuate.user.js
           retention-days: 1
 
   # Check if changes are docs-only (for release and pages deployment)
@@ -295,9 +295,9 @@ jobs:
         with:
           name: dist-release
           path: |
-            eventuate.js
-            eventuate.bookmarklet.js
-            eventuate.user.js
+            dist/eventuate.js
+            dist/eventuate.bookmarklet.js
+            docs/eventuate.user.js
           retention-days: 1
 
   # Deploy Pages after release (when we are releasing)

--- a/script/lib/create-aube-deps-pr
+++ b/script/lib/create-aube-deps-pr
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#MISE hide=true
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+BRANCH=chore/aube-deps-update
+TITLE='chore(deps): update npm dependencies'
+BODY=$'Weekly automated dependency update via aube.\n\nRequires manual review for allowBuilds changes and security advisories.'
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git checkout -B "$BRANCH"
+git add aube-lock.yaml package.json aube-workspace.yaml
+if git diff --staged --quiet; then
+  echo "No changes detected, skipping PR creation"
+  exit 0
+fi
+git commit -m "$TITLE"
+git push origin "$BRANCH" --force
+gh pr view "$BRANCH" >/dev/null 2>&1 || gh pr create \
+  --title "$TITLE" \
+  --body "$BODY" \
+  --base main \
+  --head "$BRANCH"


### PR DESCRIPTION
## Summary
- Replace the broken `peter-evans/create-pull-request` pin (invalid SHA; weekly job dies at startup) with `gh pr create` on hosted runners.
- Reuse fixed branch `chore/aube-deps-update` (force-push), create a PR only if none exists, and stage only `aube-lock.yaml` / `package.json` / `aube-workspace.yaml`.

Supersedes #225 (Copilot’s broader rewrite).

## Test plan
- [ ] Merge this PR
- [ ] Run **Update npm dependencies** via `workflow_dispatch`
- [ ] Confirm the job gets past checkout (no action-resolve error)
- [ ] If deps changed: branch force-pushed and a PR opened/updated; if not: clean skip