### PR TITLE
fix(ci): let semantic-release commit under hk hooks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -269,10 +269,17 @@ jobs:
         id: version-before
         run: echo "version=$(jq -r .version amo.json)" >> ${GITHUB_OUTPUT}
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Semantic Release
         id: semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Release prepare builds ignored artefacts; hk must not stash them.
+          HK_STASH: none
         run: aube run release
 
       - name: Version after release


### PR DESCRIPTION
## Summary
- Release failed after #229: `@semantic-release/git` commit hit hk pre-commit, which tried to stash and died with `config value 'user.name' was not found` ([run](https://github.com/johnsyweb/eventuate/actions/runs/31253990537/job/93094646929)).
- Set `github-actions[bot]` git identity before release, and `HK_STASH=none` so ignored build outputs from `prepare` are left alone.

Unblocks the pending 1.18.0 release (no tag/release was published).

## Test plan
- [x] Merge to main
- [ ] Confirm the `release` job completes and publishes the missed release
- [ ] Confirm AMO sign step runs if the version bumped